### PR TITLE
feature(bike Rental routing): query parameter useBikeRentalDockAvaila…

### DIFF
--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -635,6 +635,9 @@ public abstract class RoutingResource {
     @QueryParam("pathComparator")
     private String pathComparator;
 
+    @QueryParam("useBikeRentalDockAvailabilityInformation")
+    private Boolean useBikeRentalDockAvailabilityInformation;
+
     /**
      * somewhat ugly bug fix: the graphService is only needed here for fetching per-graph time zones. 
      * this should ideally be done when setting the routing context, but at present departure/
@@ -844,6 +847,10 @@ public abstract class RoutingResource {
         final long NOW_THRESHOLD_MILLIS = 15 * 60 * 60 * 1000;
         boolean tripPlannedForNow = Math.abs(request.getDateTime().getTime() - new Date().getTime()) < NOW_THRESHOLD_MILLIS;
         request.useBikeRentalAvailabilityInformation = tripPlannedForNow; // TODO the same thing for GTFS-RT
+
+        if (useBikeRentalDockAvailabilityInformation != null) {
+            request.useBikeRentalDockAvailabilityInformation = useBikeRentalDockAvailabilityInformation;
+        }
 
         if (startTransitStopId != null && !startTransitStopId.isEmpty())
             request.startingTransitStopId = FeedScopedId.parseId(startTransitStopId);

--- a/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/api/request/RoutingRequest.java
@@ -565,6 +565,11 @@ public class RoutingRequest implements AutoCloseable, Cloneable, Serializable {
     public boolean useBikeRentalAvailabilityInformation = false;
 
     /**
+     * Whether or not bike rental docks availability information will be used to plan bike rental trips
+     */
+    public boolean useBikeRentalDockAvailabilityInformation = true;
+
+    /**
      * Whether arriving at the destination with a rented (station) bicycle is allowed without
      * dropping it off.
      *

--- a/src/main/java/org/opentripplanner/routing/edgetype/BikeRentalEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/BikeRentalEdge.java
@@ -54,7 +54,7 @@ public class BikeRentalEdge extends Edge {
                     }
                     break;
                 case RENTING_FROM_STATION:
-                    if (options.useBikeRentalAvailabilityInformation && stationVertex.getBikesAvailable() == 0) {
+                    if (options.useBikeRentalDockAvailabilityInformation && options.useBikeRentalAvailabilityInformation && stationVertex.getBikesAvailable() == 0) {
                         return null;
                     }
                     // For arriveBy searches mayKeepRentedBicycleAtDestination is only set in State#getInitialStates(),
@@ -92,7 +92,7 @@ public class BikeRentalEdge extends Edge {
                 case RENTING_FLOATING:
                 case RENTING_FROM_STATION:
                     if (!hasCompatibleNetworks(networks, s0.getBikeRentalNetworks())) { return null; }
-                    if (options.useBikeRentalAvailabilityInformation && stationVertex.getSpacesAvailable() == 0) {
+                    if (options.useBikeRentalDockAvailabilityInformation && options.useBikeRentalAvailabilityInformation && stationVertex.getSpacesAvailable() == 0) {
                         return null;
                     }
                     s1.dropOffRentedVehicleAtStation(stationVertex.getVehicleMode(), networks, false);


### PR DESCRIPTION
https://raumobil.atlassian.net/browse/OTP-58

## Problem
Bikesharing Anbieter wie z.B. Nextbike.KVV nutzen ein System, in dem beliebig viele Räder an einer Station abgestellte werden können. Im GBFS Feed gibt es ein Property das die maximale verfügbare Anzahl von Docks angibt, an denen Räder abgestellt werden können. Nextbike.KVV gibt hier immer 0 an. Andere Nextbike Anbieter z.B. Berlin(selbes System) geben hier die tatsächliche Anzahl an. Es gibt kein eindeutiges Property, um unterscheiden zu können, ob in einem Bikesharing-System die Anzahl von verfügbaren Docks berücksichtigt werden soll.

## Aktuelles Verhalten OTP
OTP achtet aktuell immer auf die Anzahl von verfügbaren Stationen, außer man gibt in der Reqest einen Zeitpunkt weit in der Zukunft an. Da KVV bei allen Stationen, außer bei den E-Bike Stationen immer angibt es sind keine freie Docks verfügbar, navigiert OTP immer nur zu den E-Bike Stationen.

## Verhalten nach Code Änderungen OTP
Es gibt einen neuen QueryParameter "useBikeRentalDockAvailabilityInformation". 
Dieser entscheidet ob beim Abgeben des Fahrrads(State: RENTING_FROM_STATION) entweder auf die Anzahl der freien Docks gechatet werden soll oder nicht.
useBikeRentalDockAvailabilityInformation = true => achte auf die Anzahl
useBikeRentalDockAvailabilityInformation ) false => achte nicht auf die Anzahl. Es können belibig viele Räder abgegeben werden.
Per Default ist useBikeRentalDockAvailabilityInformation = true

## Mögliches weiteres Vorgehen
Auf den PMS-ez System könnte man im ProviderProfile einstellen, um welches BikeSystem es sich auf der Platform handelt. Abhäig davon kann der Broker dann den Parameter "useBikeRentalDockAvailabilityInformation" übergeben.


