### PR TITLE
ci: set TimetableSnapshotSource as error loglevel

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -34,7 +34,7 @@
 
   <logger name="org.opentripplanner.routing" level="info"/>
   <logger name="org.opentripplanner.routing.algorithm.transferoptimization" level="info"/>
-  
+
   <logger name="org.opentripplanner.routing.algorithm.GenericAStar" level="info"/>
 
   <!-- Avoid printing debug messages when walk limits are exceeded -->
@@ -56,6 +56,8 @@
   <logger name="com.conveyal" level="info"/>
 
   <!-- Avoid printing info messages about calendars when building graph -->
+  <logger name="org.opentripplanner.updater.stoptime.TimetableSnapshotSource" level="error" />
+
   <logger name="org.onebusaway.gtfs.impl.calendar.CalendarServiceDataFactoryImpl" level="warn" />
   <!-- Avoid printing ugly warning message when unable to create websocket connection -->
   <logger name="com.ning.http.client.providers.netty.NettyAsyncHttpProvider" level="error" />


### PR DESCRIPTION
ci: set TimetableSnapshotSource as error loglevel
    
Currently, we get often the warning message: "no pattern found for tripId ". This occurs, if tripId of GTFS and GTFS-RT differs. This message occurs on every update and creates a lot of logs. It could overload our Graylog.
