### PR TITLE
fix(gbfs loader): add headers to gbfs.josn request

### DIFF
--- a/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/GbfsFeedLoaderAndMapper.java
+++ b/application/src/main/java/org/opentripplanner/updater/vehicle_rental/datasources/gbfs/GbfsFeedLoaderAndMapper.java
@@ -31,7 +31,7 @@ public class GbfsFeedLoaderAndMapper {
     URI uri = new URI(params.url());
 
     var client = otpHttpClientFactory.create(LOG);
-    var gbfsNode = client.getAndMapAsJsonNode(uri, Map.of(), new ObjectMapper());
+    var gbfsNode = client.getAndMapAsJsonNode(uri, params.httpHeaders().asMap(), new ObjectMapper());
     var gbfsFeedVersion = JsonUtils.asText(gbfsNode, "version").orElse(null);
 
     switch (gbfsFeedVersion) {


### PR DESCRIPTION
### Summary

add headers of router.config to gbfs.json request

### Issue

we need auth for some gbfs endpoints. in this case the headers in the gbfs.json de are not passed

